### PR TITLE
make tealfmt usable as a module

### DIFF
--- a/cmd/tealfmt/main.go
+++ b/cmd/tealfmt/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/docopt/docopt-go"
+	"github.com/joe-p/tealfmt"
+)
+
+const (
+	version = "tealfmt v0.1.0"
+	usage   = `tealfmt
+
+Usage:
+  tealfmt <file> [ -i | --inplace ]
+  tealfmt -h | --help
+  tealfmt --version
+
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+  -i --inplace  Edit the file in place.`
+)
+
+type Config struct {
+	File    string `docopt:"<file>"`
+	InPlace bool   `docopt:"-i,--inplace"`
+}
+
+func main() {
+	opts, err := docopt.ParseArgs(usage, os.Args[1:], version)
+	if err != nil {
+		log.Fatalf("failed to parse args: %s", err)
+	}
+
+	config := Config{}
+	if err = opts.Bind(&config); err != nil {
+		log.Fatalf("failed to bind args: %s:", err)
+	}
+
+	file, err := os.Open(config.File)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	output := tealfmt.Format(file)
+
+	if config.InPlace {
+		os.WriteFile(config.File, []byte(output), 0)
+	} else {
+		fmt.Println(output)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tealfmt
+module github.com/joe-p/tealfmt
 
 go 1.18
 


### PR DESCRIPTION
Moved the tealfmt command to a separate file in a main package and the actual Format function to the tealfmt package so it can be used in other projects.