### PR TITLE
Fix comments before pragma and at end of the file

### DIFF
--- a/tealfmt.go
+++ b/tealfmt.go
@@ -76,6 +76,7 @@ func Format(r io.Reader) string {
 		// If its the pragma line, add it without modification
 		if versionMatch.MatchString(line) {
 			newLines = append(newLines, Line{Text: line, IsVoid: true, Comments: commentBuff})
+			commentBuff = nil
 			continue
 		}
 
@@ -102,6 +103,10 @@ func Format(r io.Reader) string {
 
 	if err := scanner.Err(); err != nil {
 		log.Fatalf("failed to scan file: %+v", err)
+	}
+	
+	if commentBuff != nil {
+		newLines = append(newLines, Line{Comments: commentBuff})
 	}
 
 	output := ""


### PR DESCRIPTION
Fixes tealfmt causing the following:
```
// comment 1
#pragma version 1
int 1
```
to become this after formatting:
```
// comment 1
#pragma version 1

// comment 1
int 1
```

Also fixes tealfmt removing comments at the end of a file.